### PR TITLE
Add policy source to Diagnostic

### DIFF
--- a/src/features/PerlLintProvider.ts
+++ b/src/features/PerlLintProvider.ts
@@ -122,11 +122,14 @@ export default class PerlLintProvider {
   private createDiagnostic(violation) {
     let tokens = violation.replace("~||~", "").split("~|~");
 
-    return new vscode.Diagnostic(
+    const diagnostic = new vscode.Diagnostic(
       this.getRange(tokens),
       this.getMessage(tokens),
       this.getSeverity(tokens)
-    );
+    ); 
+    diagnostic.source = this.getPolicyName(tokens);
+
+    return diagnostic;
   }
 
   private getRange(tokens) {
@@ -180,6 +183,10 @@ export default class PerlLintProvider {
       default:
         return vscode.DiagnosticSeverity.Error;
     }
+  }
+
+  private getPolicyName(tokens) {
+    return tokens[5];
   }
 
   private isValidViolation(violation) {


### PR DESCRIPTION
The metadata was already tokenized out, just had to link it up to the Diagnostic `source` property. This provides a better user experience, since you can search for the policy name and the Perl::Critic policy page will pop up. For example in the screenshot below, if you search for `ValuesAndExpressions::ProhibitEmptyQuotes` it will send you directly to the page https://metacpan.org/pod/Perl::Critic::Policy::ValuesAndExpressions::ProhibitEmptyQuotes which has a full explanation including remedies.

![perl critic policy source for diagnostic](https://user-images.githubusercontent.com/28652/85867892-18bb9200-b7b9-11ea-866f-d80f2e80259c.png)
