### PR TITLE
Defaut cwd for perl -c to workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,16 @@ machine they are using, put a `.perlcriticrc` file in the root directory of your
 ### include paths
 
 Typically you will have library folders in your project, in a subfolder `lib`.
-When you are using `carton`, the depencies are in a subfolder `local/lib/perl5`. 
+When you are using `carton`, the dependencies are in a subfolder `local/lib/perl5`. 
 
-To make the syntax check work no matter where the github repository is checked out to, you can use the following two entries in your workspace settings .json file
+To make the syntax check work no matter where your project's code is located, Perl Toolbox uses the default configuration of:
 
     "perl-toolbox.syntax.includePaths": [
         "$workspaceRoot/lib",
         "$workspaceRoot/local/lib/perl5"
     ]
+
+This is what 99% of users will need. However if you don't want this default for whatever reason, simply override the `perl-toolbox.syntax.includePaths` setting.
 
 ## Configuration
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
         },
         "perl-toolbox.syntax.path": {
           "type": "string",
-          "default": null,
+          "default": [
+            "$workspaceRoot/lib",
+            "$workspaceRoot/local/lib/perl5"
+          ],
           "description": "path to perl binary",
           "scope": "window"
         },

--- a/src/features/PerlSyntaxProvider.ts
+++ b/src/features/PerlSyntaxProvider.ts
@@ -130,6 +130,8 @@ export default class PerlSyntaxProvider {
     return {
       shell: true,
       cwd: this.configuration.path
+        ? this.configuration.path
+        : this.getWorkspaceRoot()
     };
   }
 


### PR DESCRIPTION
When spawning the `perl -c` process, set the current working directory to the workspace. This properly resolves relative paths with the `-I` flag. The end result is that `use lib 'lib';` will work out of the box without any configuration when you want to `use MyLocalPackage` that is located in your project's local `lib`. This should make the initial setup a lot easier, especially for people new to Perl to get them up and running with less friction.

I'm running it locally now and so far so good, but I'd like to test it for a bit longer before saying it's ready.