### PR TITLE
Preserve file tree in temporary directory when linting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "7.10.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.5.tgz",
-            "integrity": "sha512-RYkagUUbxQBss46ElbEa+j4q4X3GR12QwB7a/PM5hmVuVkYoW1jENT1+taspKUv8ibwW8cw+kRFbOaTc/Key3w=="
+            "version": "14.14.8",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.8.tgz",
+            "integrity": "sha512-z/5Yd59dCKI5kbxauAJgw6dLPzW+TNOItNE00PkpzNwUIEwdj/Lsqwq94H5DdYBX7C13aRA0CY32BK76+neEUA=="
         },
         "agent-base": {
             "version": "4.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1130,9 +1130,9 @@
             }
         },
         "typescript": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-            "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
+            "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
             "dev": true
         },
         "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^2.2.42",
-    "@types/node": "^7.10.5",
+    "@types/node": "^14.14.8",
     "tslint": "^5.15.0",
     "typescript": "^4.0.5",
     "vscode": "^1.1.33"

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "@types/mocha": "^2.2.42",
     "@types/node": "^7.10.5",
     "tslint": "^5.15.0",
-    "typescript": "^2.9.2",
+    "typescript": "^4.0.5",
     "vscode": "^1.1.33"
   },
   "dependencies": {

--- a/src/features/PerlLintProvider.ts
+++ b/src/features/PerlLintProvider.ts
@@ -60,26 +60,28 @@ export default class PerlLintProvider {
     }
     let decoded = "";
     this.tempfilepath = this.getTemporaryFilePath();
-    fs.writeFile(this.tempfilepath, this.document.getText(), () => {
-      let proc = cp.spawn(
-        this.configuration.exec,
-        this.getCommandArguments(),
-        this.getCommandOptions()
-      );
-      proc.stdout.on("data", (data: Buffer) => {
-        decoded += data;
-      });
-
-      proc.stderr.on("data", (data: Buffer) => {
-        console.log(`stderr: ${data}`);
-      });
-
-      proc.stdout.on("end", () => {
-        this.diagnosticCollection.set(
-          this.document.uri,
-          this.getDiagnostics(decoded)
+    fs.mkdir(this.getTemporaryFileDir(), { recursive: true }, (err) => {
+      fs.writeFile(this.tempfilepath, this.document.getText(), () => {
+        let proc = cp.spawn(
+          this.configuration.exec,
+          this.getCommandArguments(),
+          this.getCommandOptions()
         );
-        fs.unlink(this.tempfilepath, () => {});
+        proc.stdout.on("data", (data: Buffer) => {
+          decoded += data;
+        });
+
+        proc.stderr.on("data", (data: Buffer) => {
+          console.log(`stderr: ${data}`);
+        });
+
+        proc.stdout.on("end", () => {
+          this.diagnosticCollection.set(
+            this.document.uri,
+            this.getDiagnostics(decoded)
+          );
+          fs.unlink(this.tempfilepath, () => {});
+        });
       });
     });
   }
@@ -217,8 +219,14 @@ export default class PerlLintProvider {
     return configuration.temporaryPath;
   }
   
+  private getTemporaryFileDir(): string {
+    const workspaceRoot = this.getWorkspaceRoot();
+    const fileDir = path.dirname(path.relative(workspaceRoot, this.document.fileName));
+    return path.join(this.getTemporaryPath(), ".lint", fileDir);
+  }
+  
   private getTemporaryFilePath(): string {
-    return this.getTemporaryPath() + path.sep + path.basename(this.document.fileName) + ".lint";
+    return path.join(this.getTemporaryFileDir(), path.basename(this.document.fileName));
   }
 
   private useProfile(): string[] {

--- a/src/features/PerlLintProvider.ts
+++ b/src/features/PerlLintProvider.ts
@@ -59,11 +59,7 @@ export default class PerlLintProvider {
       return;
     }
     let decoded = "";
-    this.tempfilepath =
-      this.getTemporaryPath() +
-      path.sep +
-      path.basename(this.document.fileName) +
-      ".lint";
+    this.tempfilepath = this.getTemporaryFilePath();
     fs.writeFile(this.tempfilepath, this.document.getText(), () => {
       let proc = cp.spawn(
         this.configuration.exec,
@@ -219,6 +215,10 @@ export default class PerlLintProvider {
       return os.tmpdir();
     }
     return configuration.temporaryPath;
+  }
+  
+  private getTemporaryFilePath(): string {
+    return this.getTemporaryPath() + path.sep + path.basename(this.document.fileName) + ".lint";
   }
 
   private useProfile(): string[] {


### PR DESCRIPTION
This PR will fix #24.

Since older type definition of `@types/node` rejects 2nd argument (`{ recursive: true }`) of [`fs.mkdir`](https://nodejs.org/docs/latest-v14.x/api/fs.html#fs_fs_mkdir_path_options_callback), I installed latest `@types/node` and `typescript`.